### PR TITLE
chore: use virtual io ctx in tcp stream as it is more convenient

### DIFF
--- a/network/stream.h
+++ b/network/stream.h
@@ -19,14 +19,14 @@ namespace aio
         int fd_{-1};
         std::string local_endpoint_;
         std::string remote_endpoint_;
-        IoUringContext& io_ctx_;  // Add reference to io context
+        IoContextBase& io_ctx_;  // Add reference to io context
 
     public:
         Stream(const Stream&) = delete;
         Stream& operator=(const Stream&) = delete;
         Stream& operator=(Stream&& other) noexcept = delete;
 
-        Stream(const int fd_, std::string remote, std::string local, IoUringContext& io_ctx) : fd_(fd_), local_endpoint_(std::move(local)), remote_endpoint_(std::move(remote)), io_ctx_(io_ctx) {}
+        Stream(const int fd_, std::string remote, std::string local, IoContextBase& io_ctx) : fd_(fd_), local_endpoint_(std::move(local)), remote_endpoint_(std::move(remote)), io_ctx_(io_ctx) {}
 
         Stream(Stream&& other) noexcept :
             fd_(std::exchange(other.fd_, -1)), local_endpoint_(std::move(other.local_endpoint_)), remote_endpoint_(std::move(other.remote_endpoint_)), io_ctx_(other.io_ctx_)


### PR DESCRIPTION
There is no reason to use a concret implem of io context in stream class. In fact, at design point plementation of context. This is Liskov Substitution Principle in action.